### PR TITLE
Weasy local crest access

### DIFF
--- a/app/leaves/views.py
+++ b/app/leaves/views.py
@@ -17,7 +17,7 @@ from django.views.generic import View, ListView
 import os
 import io
 from phaistos.utils import convert_duration_to_words, first_name_to_geniki
-from phaistos.settings.common import BASE_DIR
+from django.conf import settings
 from django.template.loader import render_to_string
 from weasyprint import HTML
 import logging
@@ -324,9 +324,9 @@ class LeavePrintDecisionToPdfView(LoginRequiredMixin, View):
         leave = Leave.objects.get(pk = self.kwargs['pk'])
         # Select Template
         if (employee.employee_type != "ADMINISTRATIVE") and (leave.leave_type.legacy_code == "41" or leave.leave_type.legacy_code == "55"):
-            template_path = os.path.join(BASE_DIR, 'templates/leaves/template_leave_type_41_55_forward_to.html')
+            template_path = os.path.join(settings.BASE_DIR, 'templates/leaves/template_leave_type_41_55_forward_to.html')
         else:
-            template_path = os.path.join(BASE_DIR, 'templates/leaves/template_leave_type_empty.html')
+            template_path = os.path.join(settings.BASE_DIR, 'templates/leaves/template_leave_type_empty.html')
         
         context = {'employee': employee,
                    'leave': leave,
@@ -339,7 +339,7 @@ class LeavePrintDecisionToPdfView(LoginRequiredMixin, View):
         logging.getLogger('weasyprint').setLevel(logging.ERROR)
         
         content_string = render_to_string(template_path, context)#.encode('iso-8859-7')
-        print()
+        # print()
         # How to locate the Greek crest image and embed it in the pdf file:
         # In this view function I provide Weasyprint with the base URI 
         # in the form "http://<ip_address:port>/"
@@ -356,7 +356,7 @@ class LeavePrintDecisionToPdfView(LoginRequiredMixin, View):
         # e.g. in our case STATIC_ROOT = '/home/gstam/src/phaistos/phaistos/app/static_files/'
         # so, in the end the file path is 
         # /home/gstam/src/phaistos/phaistos/app/static_files/main/greek_flag_icon.png'
-        base_url=request.build_absolute_uri('/')
+        base_url= settings.STATIC_ROOT # os.path.join(BASE_DIR, "..", "static_files") #request.build_absolute_uri('/')
         HTML(string=content_string, base_url=base_url).write_pdf(buffer)
         buffer.seek(0)
         return  FileResponse(buffer, as_attachment=True, filename=f'{employee.last_name}_{employee.first_name}.pdf')

--- a/app/phaistos/commons/context_processors.py
+++ b/app/phaistos/commons/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def static_root(request):
+
+    return {
+        "STATIC_ROOT": settings.STATIC_ROOT
+    }

--- a/app/phaistos/settings/common.py
+++ b/app/phaistos/settings/common.py
@@ -62,6 +62,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'phaistos.commons.context_processors.static_root'
             ],
         },
     },
@@ -113,7 +114,7 @@ LOGOUT_REDIRECT_URL = "/"
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
-# STATIC_ROOT = '/home/gstam/src/phaistos/phaistos/app/static_files/'
+#STATIC_ROOT = '/home/gstam/src/phaistos/phaistos/app/static_files/'
 MEDIA_URL = 'media/'
 
 AUTH_USER_MODEL = "users.CustomUser"

--- a/app/phaistos/settings/common.py
+++ b/app/phaistos/settings/common.py
@@ -114,7 +114,6 @@ LOGOUT_REDIRECT_URL = "/"
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 
 STATIC_URL = 'static/'
-#STATIC_ROOT = '/home/gstam/src/phaistos/phaistos/app/static_files/'
 MEDIA_URL = 'media/'
 
 AUTH_USER_MODEL = "users.CustomUser"

--- a/app/phaistos/settings/development.py
+++ b/app/phaistos/settings/development.py
@@ -1,5 +1,5 @@
 from phaistos.settings.common import *
-
+import os
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
@@ -20,3 +20,10 @@ DATABASES = {
         'NAME': BASE_DIR / 'db.sqlite3',
     }
 }
+STATIC_ROOT = os.path.join(BASE_DIR, "..", "static_files")
+
+# STATICFILES_DIRS = [
+#     BASE_DIR / "static_files",
+# ]
+# print(STATICFILES_DIRS)
+# print(f'My base dir is: {os.path.join(BASE_DIR, "..", "static_files")}')

--- a/app/phaistos/templates/base.html
+++ b/app/phaistos/templates/base.html
@@ -3,10 +3,6 @@
 {% load django_bootstrap5 %}
 
 {% block bootstrap5_extra_head %}
-
-<p>
-    {{ STATIC_ROOT }}/main/greek_flag_icon.png
-</p>
 <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
 <script src="{% static 'js/jquery.bootstrap.modal.forms.js' %}"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css">

--- a/app/phaistos/templates/leaves/template_leave_type_41_55_forward_to.html
+++ b/app/phaistos/templates/leaves/template_leave_type_41_55_forward_to.html
@@ -7,7 +7,7 @@
     @font-face {
         font-family: DejaVu-Sans;
         font-size: 14pt;
-        {% comment %} src: file://{{ STATIC_ROOT }}/main/fonts/Kerkis-Bold.ttf ; {% endcomment %}
+        {% comment %} src: url({% static 'main/fonts/Kerkis-Bold.ttf' %}); {% endcomment %}
     }
    
     @page {
@@ -134,7 +134,7 @@
   <div class="break">
     <div class="prometopida">
         <div id="foreas">
-            <img src="file://{{STATIC_ROOT}}/main/greek_flag_icon.png" class="greek_flag_image" class="center-flag" alt="Σημαία" alt="Τεστ">
+            <img src={% static 'main/greek_flag_icon.png'%} class="greek_flag_image" class="center-flag" alt="Σημαία" alt="Τεστ">
             ΕΛΛΗΝΙΚΗ ΔΗΜΟΚΡΑΤΙΑ <br>
             ΥΠΟΥΡΓΕΙΟ ΠΑΙΔΕΙΑΣ & ΘΡΗΣΚΕΥΜΑΤΩΝ <br>
             <div class="thin-dashed-line"> ----- </div>

--- a/app/phaistos/templates/leaves/template_leave_type_41_55_forward_to.html
+++ b/app/phaistos/templates/leaves/template_leave_type_41_55_forward_to.html
@@ -134,7 +134,7 @@
   <div class="break">
     <div class="prometopida">
         <div id="foreas">
-            <img src={% static 'main/greek_flag_icon.png'%} class="greek_flag_image" class="center-flag" alt="Σημαία" alt="Τεστ">
+            <img src='main/greek_flag_icon.png' class="greek_flag_image" class="center-flag" alt="Σημαία" alt="Τεστ">
             ΕΛΛΗΝΙΚΗ ΔΗΜΟΚΡΑΤΙΑ <br>
             ΥΠΟΥΡΓΕΙΟ ΠΑΙΔΕΙΑΣ & ΘΡΗΣΚΕΥΜΑΤΩΝ <br>
             <div class="thin-dashed-line"> ----- </div>


### PR DESCRIPTION
Φίλιππε άλλαξα το μηχανισμό φόρτωσης του Ελληνικού οικόσημου. Αρχικά η εύρεση του εικονίδιου γινόταν με GET από το Weasyprint και ενέπλεκε τον μηχανισμό url routing του Django. Τώρα περνάει μόνο μέσα από το filesystem. 

Δυστυχώς για να δουλέψει σωστά έπρεπε να χρησιμοποιήσω την STATIC_ROUTE μεταβλητή περιβάλλοντος. Την έβγαλα λοιπόν από το production και το development και την έβαλα στο commons.py. Εκεί την ορίζω με generic τρόπο που δουλεύει για το development. Δεν την έχω ελέγξει για το stagin/production.
