### PR TITLE
fix AttributeError in LeavePrintDecisionToPdfView:get

### DIFF
--- a/app/leaves/views.py
+++ b/app/leaves/views.py
@@ -356,10 +356,10 @@ class LeavePrintDecisionToPdfView(LoginRequiredMixin, View):
                 template_path = os.path.join(settings.BASE_DIR, 'templates/leaves/template_leave_type_empty.html')
         
         is_education_consultant, education_consultant_specialization = employee_is_education_consultant()
-        
+        school_principal_unit = employee.school_principal_unit.title if employee.school_principal_unit else None
         context = {'employee': employee,
                    'is_principal': employee.is_school_principal,
-                   'principal_school_unit': employee.school_principal_unit.title,
+                   'principal_school_unit': school_principal_unit,
                    'is_education_consultant': is_education_consultant,
                    'education_consultant_specialization': education_consultant_specialization,
                    'leave': leave,


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/opt/venv/lib/python3.9/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
  File "/opt/venv/lib/python3.9/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/opt/venv/lib/python3.9/site-packages/django/views/generic/base.py", line 84, in view
    return self.dispatch(request, *args, **kwargs)
  File "/opt/venv/lib/python3.9/site-packages/django/contrib/auth/mixins.py", line 73, in dispatch
    return super().dispatch(request, *args, **kwargs)
  File "/opt/venv/lib/python3.9/site-packages/django/views/generic/base.py", line 119, in dispatch
    return handler(request, *args, **kwargs)
  File "/app/leaves/views.py", line 362, in get
    'principal_school_unit': employee.school_principal_unit.title,
AttributeError: 'NoneType' object has no attribute 'title'
```